### PR TITLE
Update ATH9KFixup Info

### DIFF
--- a/KnownPlugins.md
+++ b/KnownPlugins.md
@@ -8,7 +8,7 @@ Please note that improperly written immature plugins will not be listed there.
 |:-----|:------------------|:----|
 [AirportBrcmFixup](https://sourceforge.net/p/airportbrcmfixup) | Various patches for Broadcom Airport Wi-Fi cards | 1.1.0+
 [AppleALC](https://github.com/vit9696/AppleALC) | Native macOS HD audio for not officially supported codecs | 1.2.0+
-[ATH9KFixup](https://github.com/chunnann/ATH9KFixup) | Various patches for unsupported Atheros Wi-Fi cards | NO
+[ATH9KFixup](https://github.com/black-dragon74/ATH9KFixup) | Various patches for unsupported Atheros Wi-Fi cards | 1.2.0+
 [AzulPatcher4600](https://github.com/coderobe/AzulPatcher4600) | Additional Intel HD 4600 patches for some laptops on 10.12.4+ | 1.2.0+
 [BT4LEContiunityFixup](https://sourceforge.net/p/bt4lecontiunityfixup) | Enable BT4LE-Handoff-Hotspot features | 1.1.0+
 [CoreDisplayFixup](https://github.com/PMheart/CoreDisplayFixup) | Non Iris Intel graphics high resolution support | 1.3.0+


### PR DESCRIPTION
As the developer of the plugin hasn't updated the kext yet, I have forked it and added support for Lilu 1.2.0

It would be nice if people get to know about this from the officials plugin page.